### PR TITLE
fix: project partners from IP4 not displaying

### DIFF
--- a/data/industry.tsx
+++ b/data/industry.tsx
@@ -7,47 +7,47 @@ interface Partner {
 export const partners_ip4: Partner[] = [
   {
     href: "https://www.atoss.com/de",
-    src: "/assets/industry/partners/ATOSS.png",
+    src: "/assets/industry/partners/IP4/ATOSS.png",
     alt: "atoss",
   },
   {
     href: "https://www.hypovereinsbank.de",
-    src: "/assets/industry/partners/HVB_2.png",
+    src: "/assets/industry/partners/IP4/HVB_2.png",
     alt: "hypovereinsbank",
   },
   {
     href: "https://www.infineon.com/cms/de/",
-    src: "/assets/industry/partners/infineon_logo.png",
+    src: "/assets/industry/partners/IP4/infineon_logo.png",
     alt: "infineon",
   },
   {
     href: "https://www.prosiebensat1.com",
-    src: "/assets/industry/partners/P7S1_transparent.png",
+    src: "/assets/industry/partners/IP4/P7S1_transparent.png",
     alt: "prosiebensat1",
   },
   {
     href: "https://www.sportortho.mri.tum.de",
-    src: "/assets/industry/partners/MRI.png",
+    src: "/assets/industry/partners/IP4/MRI.png",
     alt: "MRI",
   },
   {
     href: "https://neuralprophet.com",
-    src: "/assets/industry/partners/neuralprophet_logo.png",
+    src: "/assets/industry/partners/IP4/neuralprophet_logo.png",
     alt: "neuralprophet",
   },
   {
     href: "https://eyeo.com",
-    src: "/assets/industry/partners/eyeo.png",
+    src: "/assets/industry/partners/IP4/eyeo.png",
     alt: "eyeo",
   },
   {
     href: "https://gruppe.schwarz",
-    src: "/assets/industry/partners/schwarzgroup_edit_cropped.png",
+    src: "/assets/industry/partners/IP4/schwarzgroup_edit_cropped.png",
     alt: "Schwarz Gruppe",
   },
   {
     href: "https://www.rohde-schwarz.com/de",
-    src: "/assets/industry/partners/RandS.svg.png",
+    src: "/assets/industry/partners/IP4/RandS.svg.png",
     alt: "Rhode-Schwarz",
   },
 ];

--- a/data/partners.tsx
+++ b/data/partners.tsx
@@ -1,4 +1,4 @@
-import { partners_ip4 } from "./industry";
+import { partners_ip4, partners_ip5 } from "./industry";
 
 export const partners_collabrated_with = [
   {
@@ -349,4 +349,7 @@ export const project_partners = [
     src: "/assets/partners_sponsors/avi_medical_logo.png",
     alt: "Avi Medical",
   },
-].concat(partners_ip4);
+]
+  .concat(partners_ip4)
+  .concat(partners_ip5)
+  .filter((element) => element.alt != "HVB");


### PR DESCRIPTION
Previous industry partners were not using correct file paths due to newly introduced assets/industry/partners/IP4 and IP5 directories.