### PR TITLE
feat: Startup detail pages

### DIFF
--- a/app/e-lab/startups/[id]/page.tsx
+++ b/app/e-lab/startups/[id]/page.tsx
@@ -1,0 +1,18 @@
+import startups from '@data/e-lab-startups.json';
+import StartupDetails from '@components/StartupDetails';
+
+export async function generateStaticParams() {
+    return startups.map((startup) => ({
+        id: startup.id,
+    }));
+}
+
+export default function StartupPage({ params }: { params: { id: string } }) {
+    const startup = startups.find((s) => s.id === params.id);
+
+    if (!startup) {
+        return <div>Startup not found</div>;
+    }
+
+    return <StartupDetails startup={startup} />;
+}

--- a/app/e-lab/startups/[id]/page.tsx
+++ b/app/e-lab/startups/[id]/page.tsx
@@ -2,9 +2,9 @@ import startups from '@data/e-lab-startups.json';
 import StartupDetails from '@components/StartupDetails';
 
 export async function generateStaticParams() {
-    return startups.map((startup) => ({
+    return await Promise.resolve(startups.map((startup) => ({
         id: startup.id,
-    }));
+    })));
 }
 
 export default function StartupPage({ params }: { params: { id: string } }) {

--- a/app/e-lab/startups/[id]/page.tsx
+++ b/app/e-lab/startups/[id]/page.tsx
@@ -1,17 +1,17 @@
-import startups from '@data/e-lab-startups.json';
+import { startups, Startup} from '@data/e-lab-startups';
 import StartupDetails from '@components/StartupDetails';
 
-export async function generateStaticParams() {
-    return await Promise.resolve(startups.map((startup) => ({
-        id: startup.id,
-    })));
-}
-
 export default function StartupPage({ params }: { params: { id: string } }) {
-    const startup = startups.find((s) => s.id === params.id);
+
+    const startup: Startup | undefined = startups.find((startup: Startup) => {
+        if (startup && startup.id === params.id) {
+            return startup;
+        }
+        return undefined;
+    });
 
     if (!startup) {
-        return <div>Startup not found</div>;
+        return <div>Startup Not Found</div>;
     }
 
     return <StartupDetails startup={startup} />;

--- a/app/hero.tsx
+++ b/app/hero.tsx
@@ -27,7 +27,7 @@ export const Hero = () => {
               distort={0.3}
               wireframe={true}
               wireframeLinewidth={5}
-              color={fullConfig.theme.colors.purple["600"]}
+              color={(fullConfig.theme?.colors?.purple?.["600"] as string) ?? "#000000"}
               transparent
               opacity={0.4}
               blending={THREE.AdditiveBlending}

--- a/components/StartupDetails.tsx
+++ b/components/StartupDetails.tsx
@@ -1,32 +1,31 @@
+"use client";
+
 import Image from 'next/image';
 import Link from 'next/link';
 import { Startup } from '@data/e-lab';
+import { useState } from 'react';
 
 const StartupDetails = ({ startup }: { startup: Startup }) => {
+  const [imageError, setImageError] = useState(false);
+
   return (
-    <div className="bg-purple-950 text-white min-h-screen p-8">
+    <div className="bg-purple-950 text-white min-h-screen pt-16 p-8">
       <div className="max-w-4xl mx-auto">
-        <div className="flex items-center mb-8">
-          <Image
-            src={startup.logo}
-            alt={`${startup.name} logo`}
-            width={100}
-            height={100}
-            className="mr-4"
-          />
+
+        <div className="flex items-center justify-between mb-8" style={{ height: '100px', width: '100px' }}>
           <h1 className="text-4xl font-bold">{startup.name}</h1>
+          {!imageError && (
+            <Image 
+              src={startup.logo} 
+              alt={`${startup.name} logo`} 
+              width={100} 
+              height={100}
+              onError={() => setImageError(true)}
+            />
+          )}
         </div>
 
         <p className="text-xl mb-8">{startup.description}</p>
-
-        <h2 className="text-2xl font-semibold mb-4">Founders</h2>
-        <ul className="mb-8">
-          {startup.founders.map((founder) => (
-            <li key={founder.name} className="mb-2">
-              <span className="font-bold">{founder.name}</span> - {founder.role}
-            </li>
-          ))}
-        </ul>
 
         <h2 className="text-2xl font-semibold mb-4">Metrics</h2>
         <ul className="mb-8">
@@ -39,6 +38,15 @@ const StartupDetails = ({ startup }: { startup: Startup }) => {
 
         <h2 className="text-2xl font-semibold mb-4">About {startup.name}</h2>
         <p className="mb-8">{startup.about}</p>
+
+        <h2 className="text-2xl font-semibold mb-4">Founders</h2>
+        <ul className="mb-8">
+          {startup.founders.map((founder) => (
+            <li key={founder.name} className="mb-2">
+              <span className="font-bold">{founder.name}</span> - {founder.role}
+            </li>
+          ))}
+        </ul>        
 
         <Link
           href={startup.website}

--- a/components/StartupDetails.tsx
+++ b/components/StartupDetails.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+const StartupDetails = ({ startup }: { startup: any }) => {
+  return (
+    <div className="bg-purple-950 text-white min-h-screen p-8">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center mb-8">
+          <Image
+            src={startup.logo}
+            alt={`${startup.name} logo`}
+            width={100}
+            height={100}
+            className="mr-4"
+          />
+          <h1 className="text-4xl font-bold">{startup.name}</h1>
+        </div>
+
+        <p className="text-xl mb-8">{startup.description}</p>
+
+        <h2 className="text-2xl font-semibold mb-4">Founders</h2>
+        <ul className="mb-8">
+          {startup.founders.map((founder: any) => (
+            <li key={founder.name} className="mb-2">
+              <span className="font-bold">{founder.name}</span> - {founder.role}
+            </li>
+          ))}
+        </ul>
+
+        <h2 className="text-2xl font-semibold mb-4">Metrics</h2>
+        <ul className="mb-8">
+          {Object.entries(startup.metrics).map(([key, value]) => (
+            <li key={key} className="mb-2">
+              <span className="font-bold">{key}:</span> {String(value)}
+            </li>
+          ))}
+        </ul>
+
+        <h2 className="text-2xl font-semibold mb-4">About {startup.name}</h2>
+        <p className="mb-8">{startup.about}</p>
+
+        <Link
+          href={startup.website}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="bg-yellow-500 text-black px-4 py-2 rounded-full font-semibold hover:bg-yellow-600 transition-colors"
+        >
+          Visit Website
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default StartupDetails;

--- a/components/StartupDetails.tsx
+++ b/components/StartupDetails.tsx
@@ -1,7 +1,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { Startup } from '@data/e-lab';
 
-const StartupDetails = ({ startup }: { startup: any }) => {
+const StartupDetails = ({ startup }: { startup: Startup }) => {
   return (
     <div className="bg-purple-950 text-white min-h-screen p-8">
       <div className="max-w-4xl mx-auto">
@@ -20,7 +21,7 @@ const StartupDetails = ({ startup }: { startup: any }) => {
 
         <h2 className="text-2xl font-semibold mb-4">Founders</h2>
         <ul className="mb-8">
-          {startup.founders.map((founder: any) => (
+          {startup.founders.map((founder) => (
             <li key={founder.name} className="mb-2">
               <span className="font-bold">{founder.name}</span> - {founder.role}
             </li>

--- a/data/e-lab-startups.json
+++ b/data/e-lab-startups.json
@@ -1,0 +1,30 @@
+[
+    {
+        "id": "airbnb",
+        "name": "Airbnb",
+        "description": "Airbnb is an online marketplace for short-term homestays and experiences.",
+        "founders": [
+            {
+            "name": "Brian Chesky",
+            "role": "CEO, Co-founder"
+            },
+            {
+            "name": "Joe Gebbia",
+            "role": "Co-founder"
+            },
+            {
+            "name": "Nathan Blecharczyk",
+            "role": "Chief Strategy Officer, Co-founder"
+            }
+        ],
+        "metrics": {
+            "Year Founded": "2008",
+            "Valuation": "$113 billion",
+            "Funding Raised": "$6.4 billion",
+            "Employees": "6,132"
+        },
+        "about": "Airbnb has revolutionized the travel industry by allowing homeowners to rent out their spaces to travelers. Founded in 2008, the company has grown from a small startup to a global phenomenon, operating in over 220 countries and regions. Airbnb's platform not only provides unique accommodation options for travelers but also empowers hosts to earn extra income. The company's success lies in its ability to create a trusted community marketplace and its continuous innovation in the travel and hospitality sector.",
+        "website": "https://www.airbnb.com",
+        "logo": "/assets/e-lab/startups/airbnb-logo.png"
+    }
+]

--- a/data/e-lab-startups.tsx
+++ b/data/e-lab-startups.tsx
@@ -1,4 +1,22 @@
-[
+export interface Startup {
+    id: string;
+    name: string;
+    description: string;
+    founders: Founder[];
+    metrics: Metrics;
+    website: string;
+    logo: string;
+    about?: string;
+}
+
+export interface Founder {
+    name: string;
+    role: string;
+}
+
+export type Metrics = Record<string, string>;
+
+export const startups: Startup[] = [
     {
         "id": "airbnb",
         "name": "Airbnb",
@@ -27,4 +45,4 @@
         "website": "https://www.airbnb.com",
         "logo": "/assets/e-lab/startups/airbnb-logo.png"
     }
-]
+];

--- a/data/e-lab.tsx
+++ b/data/e-lab.tsx
@@ -145,3 +145,21 @@ export const faq = [
       "The AI E-Lab is a part-time program. Keep in mind that the more you commit, the more you get out of this program.",
   },
 ];
+
+export interface Founder {
+  name: string;
+  role: string;
+}
+
+export type Metrics = Record<string, string>;
+
+export interface Startup {
+  id: string;
+  name: string;
+  description: string;
+  founders: Founder[];
+  metrics: Metrics;
+  website: string;
+  logo: string;
+  about?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,9 @@
       "@components/*": [
         "./components/*"
       ],
+      "@data/*": [
+        "./data/*"
+      ],
       "@ui/*": [
         "./components/ui/*"
       ],


### PR DESCRIPTION
Venture has to input their own data, required structure can be found in data/e-lab-startups.json

Example detail page can be found at:
http://localhost:3000/e-lab/startups/airbnb

An overview of the startups can also be embedded like this in e-lab/page.tsx:

```tsx
<Section className="bg-purple-950 text-white">
  <h2 className="mb-12 bg-gradient-to-r from-yellow-500 to-red-500 bg-clip-text text-center text-3xl font-semibold uppercase tracking-widest text-transparent sm:text-5xl">
    Our Startups
  </h2>
  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
    {startups.map((startup) => (
      <Link
        key={startup.id}
        href={`/e-lab/startups/${startup.id}`}
        className="bg-purple-900 p-6 rounded-lg hover:bg-purple-800 transition-colors"
      >
        <h3 className="text-2xl font-semibold mb-2">{startup.name}</h3>
        <p className="text-gray-300">{startup.description}</p>
      </Link>
    ))}
  </div>
</Section>
```